### PR TITLE
Assorted build system fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,7 @@ dnl AM_ACLOCAL_INCLUDE(.)
 dnl AM_CONFIG_HEADER(include/libvcd/acconfig.h)
 AM_CONFIG_HEADER(config.h)
 
-LIBVCD_VERSION_NUM=RELEASE_NUM
+LIBVCD_VERSION_NUM=$(echo RELEASE_NUM | sed 's/git$//')
 AC_SUBST(LIBVCD_VERSION_NUM)
 
 AM_MISSING_PROG(HELP2MAN, help2man, $missing_dir)

--- a/configure.ac
+++ b/configure.ac
@@ -151,11 +151,11 @@ dnl For vcdimager and vcdxbuild to be able to set creation time of VCD
 AC_CHECK_FUNCS(getdate strptime, , )
 
 if test "x$enable_cli_fe" = "xyes" -o "x$enable_xml_fe" = "xyes"; then
-  AM_PATH_LIBPOPT(, [enable_cli_fe=no; enable_xml_fe=no])
+  PKG_CHECK_MODULES(LIBPOPT, popt, [], [enable_cli_fe=no; enable_xml_fe=no])
 fi
 
 if test "x$enable_xml_fe" = "xyes"; then
-  AM_PATH_XML2(2.3.8, , enable_xml_fe=no)
+  PKG_CHECK_MODULES(XML, libxml-2.0 >= 2.3.8, [], [enable_xml_fe=no])
 fi
 
 dnl headers

--- a/configure.ac
+++ b/configure.ac
@@ -208,7 +208,7 @@ fi
 #
 AC_MSG_CHECKING([bitfield ordering in structs])
 dnl basic compile test for all platforms
-AC_COMPILE_IFELSE([
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
 int
  main() {
   struct { char bit_0:1, bit_12:2, bit_345:3, bit_67:2; }
@@ -219,10 +219,10 @@ int
   switch (0) case 0: case sizeof(bf) == 1:;
   return 0;
 }
-], [], AC_MSG_ERROR([compiler doesn't support bitfield structs]))
+]])], [], AC_MSG_ERROR([compiler doesn't support bitfield structs]))
 
 dnl run test
-AC_RUN_IFELSE([
+AC_RUN_IFELSE([AC_LANG_SOURCE([[
 int main() {
   struct { char bit_0:1, bit_12:2, bit_345:3, bit_67:2; }
 #if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ > 4)
@@ -231,8 +231,8 @@ int main() {
   bf = { 1,1,1,1 };
   if (sizeof (bf) != 1) return 1;
   return *((unsigned char*) &bf) != 0x4b; }
-], bf_lsbf=1, [
-  AC_RUN_IFELSE([
+]])], bf_lsbf=1, [
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[
 int main() {
   struct { char bit_0:1, bit_12:2, bit_345:3, bit_67:2; }
 #if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ > 4)
@@ -241,7 +241,7 @@ int main() {
  bf = { 1,1,1,1 };
  if (sizeof (bf) != 1) return 1;
  return *((unsigned char*) &bf) != 0xa5; }
-], bf_lsbf=0, AC_MSG_ERROR([unsupported bitfield ordering]))
+]])], bf_lsbf=0, AC_MSG_ERROR([unsupported bitfield ordering]))
   ],
   [case "$host" in
      *-*-mingw32* | *-*-cygwin*)

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -22,7 +22,7 @@
 
 noinst_PROGRAMS = info1 info2
 
-INCLUDES      = -I$(top_srcdir) $(LIBVCD_CFLAGS) $(LIBCDIO_CFLAGS)
+AM_CPPFLAGS   = -I$(top_srcdir) $(LIBVCD_CFLAGS) $(LIBCDIO_CFLAGS)
 
 info1_LDADD   = $(LIBVCDINFO_LIBS) $(LIBVCD_LIBS) $(LIBISO9660_LIBS)
 info2_SOURCES = info2.cpp

--- a/frontends/xml/Makefile.am
+++ b/frontends/xml/Makefile.am
@@ -21,7 +21,7 @@ bin_PROGRAMS = vcdxbuild vcdxgen vcdxrip vcdxminfo
 man_MANS = vcdxbuild.1 vcdxgen.1 vcdxrip.1 vcdxminfo.1
 
 if MAINTAINER_MODE
-$(man_MANS): %.1:
+$(man_MANS): %.1: %$(EXEEXT)
 	-$(HELP2MAN) --no-info --libtool -o $@ ./$<
 endif
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,6 +1,6 @@
 noinst_PROGRAMS = mpegscan mpegscan2 testimage testassert testvcd
 
-AM_CPPFLAGS = -I$(top_srcdir) $(POPT_CFLAGS) $(LIBVCD_CFLAGS) $(LIBCDIO_CFLAGS)
+AM_CPPFLAGS = -I$(top_srcdir) $(LIBPOPT_CFLAGS) $(LIBVCD_CFLAGS) $(LIBCDIO_CFLAGS)
 
 mpegscan_LDADD = $(LIBVCD_LIBS) $(LIBISO9660_LIBS)
 mpegscan2_LDADD = $(LIBVCD_LIBS) $(LIBISO9660_LIBS)


### PR DESCRIPTION
Most of these should be uncontroversial. The PKG_CHECK_MODULES one may be worth a look in case vcdimager needs to support some ancient system where popt or libxml2 doesn't provide a .pc file.

(Thanks for vcdimager - I've got a lot of use out of it over the years!)