### PR TITLE
build system: essential fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,10 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 # 02111-1307, USA.
 
-SUBDIRS = include lib frontends test docs example
+SUBDIRS = include lib frontends test example
+if ENABLE_DOC
+SUBDIRS += docs
+endif
 
 # pkg-config(1) related rules
 pkgconfigdir = $(libdir)/pkgconfig

--- a/autogen.sh
+++ b/autogen.sh
@@ -15,7 +15,7 @@ DIE=0
 }
 
 (grep "^AM_PROG_LIBTOOL" $srcdir/configure.ac >/dev/null) && {
-  (libtool --version) < /dev/null > /dev/null 2>&1 || {
+  (libtoolize --version) < /dev/null > /dev/null 2>&1 || {
     echo
     echo "**Error**: You must have \`libtool' installed."
     echo "Get ftp://ftp.gnu.org/pub/gnu/libtool-1.2d.tar.gz"

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,13 @@ AC_PROG_CXX
 
 AC_DEFINE_UNQUOTED(HOST_ARCH, "$host_os/$host_cpu", [host os/cpu identifier])
 
+AC_ARG_ENABLE(doc,
+	[AS_HELP_STRING([--disable-doc],[Do not build documentation])],
+	[enable_doc="${enableval}"],
+	[enable_doc=yes]
+)
+AM_CONDITIONAL(ENABLE_DOC, test "x$enable_doc" = "xyes")
+
 dnl conditionally built frontends
 
 AC_ARG_WITH(cli-frontend,

--- a/configure.ac
+++ b/configure.ac
@@ -268,6 +268,7 @@ int main() {
      *-*-mingw32* | *-*-cygwin*)
        bf_lsbf=1
      ;;
+     *-linux-*) bf_lsbf=1 ;;
      *)
        AC_MSG_RESULT([unknown])
        AC_MSG_ERROR([value of bitfield test isn't known for $host

--- a/frontends/cli/Makefile.am
+++ b/frontends/cli/Makefile.am
@@ -28,9 +28,8 @@ cdxa2mpeg_LDADD =  $(LIBISO9660_LIBS) $(LIBVCD_LIBS) $(LIBPOPT_LIBS)
 vcd_info_SOURCES = vcd-info.c
 vcd_info_LDADD = $(LIBISO9660_LIBS) $(LIBVCDINFO_LIBS) $(LIBVCD_LIBS) $(LIBPOPT_LIBS) $(LIBCDIO_LIBS) $(LIBISO9660_LIBS)
 
+if ENABLE_DOC
 man_MANS = vcdimager.1 cdxa2mpeg.1 vcd-info.1
-
-if MAINTAINER_MODE
 vcdimager.1: vcdimager$(EXEEXT)
 	-$(HELP2MAN) --name "Generates simple pbc-less VCD and SVCD disc images directly" --no-info --libtool -o $@ ./$<
 

--- a/frontends/xml/Makefile.am
+++ b/frontends/xml/Makefile.am
@@ -18,9 +18,8 @@
 
 bin_PROGRAMS = vcdxbuild vcdxgen vcdxrip vcdxminfo
 
+if ENABLE_DOC
 man_MANS = vcdxbuild.1 vcdxgen.1 vcdxrip.1 vcdxminfo.1
-
-if MAINTAINER_MODE
 vcdxbuild.1: vcdxbuild$(EXEEXT)
 	-$(HELP2MAN) --name "Builds a VCD/SVCD according to a supplied XML control file" --no-info --libtool -o $@ ./$<
 


### PR DESCRIPTION
- autogen.sh: check for libtoolize instead of libtool
    
    the libtool binary is not needed and sometimes is not installed
    
    Debian: it can be found in libtool-bin

- configure.ac: fix cross compiling for Linux
    
    vcdimager only supports LSBF as bitfield order in structs
    
    and that's what gcc produces

- option to enable/disable docs (enabled by default)
    
    sometimes the system is missing an app to build documentation
    or the app is malfunctioning for some reason,
    so it's a good idea to disable documentation so that the app compiles and installs successfully
    
    --disable-doc to not build documentation
